### PR TITLE
Add token counter FastAPI server

### DIFF
--- a/servers/token_counter/Dockerfile
+++ b/servers/token_counter/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim as base
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+ARG UID=10001
+RUN adduser --disabled-password --gecos "" --home "/nonexistent" --shell "/sbin/nologin" --no-create-home --uid "${UID}" appuser
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=requirements.txt,target=requirements.txt \
+    pip install -r requirements.txt
+USER appuser
+COPY . .
+EXPOSE 8000
+CMD uvicorn 'main:app' --host=0.0.0.0 --port=8000

--- a/servers/token_counter/README.md
+++ b/servers/token_counter/README.md
@@ -1,0 +1,19 @@
+# 🧮 Token Counter Server
+
+A tiny FastAPI service (v0.0.1) that counts tokens in text using [tiktoken](https://github.com/openai/tiktoken).
+It understands models such as `gpt-3.5-turbo`, `gpt-4o` and also falls back for
+unknown models like `gpt-4.1`.
+
+> **Note**
+> The server expects **Python 3.12** when run locally or in Docker.
+
+## 🚀 Quickstart
+
+```bash
+git clone <your repo here>
+cd OpenAPI-tools/servers/token_counter
+pip install -r requirements.txt
+uvicorn main:app --host 0.0.0.0 --reload
+```
+
+Visit `http://localhost:8000/docs` to try it out.

--- a/servers/token_counter/compose.yaml
+++ b/servers/token_counter/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  server:
+    build:
+      context: .
+    ports:
+      - 8000:8000

--- a/servers/token_counter/main.py
+++ b/servers/token_counter/main.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+import tiktoken
+
+app = FastAPI(
+    title="Token Counter API",
+    version="0.0.1",
+    description="Simple API to count tokens for a given text"
+)
+
+class TokenCountInput(BaseModel):
+    text: str = Field(..., description="Text to tokenize")
+    model: str = Field(
+        "gpt-3.5-turbo",
+        description="Model name for tokenization (determines encoding)",
+    )
+
+@app.post("/count_tokens", summary="Count tokens in text")
+def count_tokens(data: TokenCountInput):
+    """Return the number of tokens for the given text and model."""
+    try:
+        # tiktoken supports gpt-3.5-turbo and gpt-4o directly
+        encoding = tiktoken.encoding_for_model(data.model)
+    except Exception:
+        # gpt-4.1 or unknown models fallback to cl100k_base or o200k_base
+        fallback_map = {
+            "gpt-4o": "o200k_base",
+            "gpt-4.1": "o200k_base",
+        }
+        encoding = tiktoken.get_encoding(fallback_map.get(data.model, "cl100k_base"))
+    num_tokens = len(encoding.encode(data.text))
+    return {"tokens": num_tokens}
+
+@app.get("/health", summary="Health check")
+def health():
+    return {"status": "ok"}

--- a/servers/token_counter/requirements.txt
+++ b/servers/token_counter/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+pydantic
+tiktoken


### PR DESCRIPTION
## Summary
- add a `token_counter` FastAPI server for quick token counting
- include Dockerfile and compose file for easy running
- set version to `0.0.1` and add fallback encoding for `gpt-4o` and `gpt-4.1`
- use Python 3.12 for Docker image
- document Python 3.12 requirement

## Testing
- `python - <<'PY'
from servers.token_counter.main import count_tokens, TokenCountInput
print(count_tokens(TokenCountInput(text='hello world')))
print(count_tokens(TokenCountInput(text='hello world', model='gpt-4o')))
print(count_tokens(TokenCountInput(text='hello world', model='gpt-4.1')))
PY`
- `uvicorn servers.token_counter.main:app --port 8000 --host 127.0.0.1 --log-level warning & sleep 2; pgrep -f "uvicorn"; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_6846c6defb50832b92a0a6df7c02526d