### PR TITLE
Add Confluence API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # OpenAPI-tools
 Within this repo I have OpenAPI-tools which you can use as MCP or directly with AI
+
+## Servers
+- `token_counter` – Simple API that counts tokens using tiktoken
+- `confluence_toolset_with_scope_restrictions` – API for reading and writing Confluence Cloud pages

--- a/servers/confluence_toolset_with_scope_restrictions/Dockerfile
+++ b/servers/confluence_toolset_with_scope_restrictions/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim as base
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+ARG UID=10001
+RUN adduser --disabled-password --gecos "" --home "/nonexistent" --shell "/sbin/nologin" --no-create-home --uid "${UID}" appuser
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=requirements.txt,target=requirements.txt \
+    pip install -r requirements.txt
+USER appuser
+COPY . .
+EXPOSE 8000
+CMD uvicorn 'main:app' --host=0.0.0.0 --port=8000

--- a/servers/confluence_toolset_with_scope_restrictions/README.md
+++ b/servers/confluence_toolset_with_scope_restrictions/README.md
@@ -1,0 +1,18 @@
+# 📝 Confluence Toolset with Scope Restrictions
+
+A simple FastAPI server to interact with Confluence Cloud pages.
+
+## Environment Variables
+- `CONFLUENCE_URL` – Base URL of your Confluence Cloud instance (e.g. `https://your-site.atlassian.net/`)
+- `CONFLUENCE_USERNAME` – Username or email used for authentication
+- `CONFLUENCE_TOKEN` – API token for authentication
+- `CONFLUENCE_SPACE_KEY` – Space key where new pages are created
+- `CONFLUENCE_PARENT_PAGE` – *(optional)* Parent page ID limiting write operations
+
+## Quickstart
+```bash
+cd OpenAPI-tools/servers/confluence_toolset_with_scope_restrictions
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+Then visit [http://localhost:8000/docs](http://localhost:8000/docs).

--- a/servers/confluence_toolset_with_scope_restrictions/compose.yaml
+++ b/servers/confluence_toolset_with_scope_restrictions/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  server:
+    build:
+      context: .
+    ports:
+      - 8000:8000

--- a/servers/confluence_toolset_with_scope_restrictions/confluence_client.py
+++ b/servers/confluence_toolset_with_scope_restrictions/confluence_client.py
@@ -1,0 +1,149 @@
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+from fastapi import HTTPException
+
+
+class ConfluenceClient:
+    """Simple client for interacting with Confluence Cloud."""
+
+    def __init__(self) -> None:
+        self.url = os.environ.get("CONFLUENCE_URL")
+        self.username = os.environ.get("CONFLUENCE_USERNAME")
+        self.token = os.environ.get("CONFLUENCE_TOKEN")
+        self.space_key = os.environ.get("CONFLUENCE_SPACE_KEY")
+        self.parent_page = os.environ.get("CONFLUENCE_PARENT_PAGE")
+        if not all([self.url, self.username, self.token]):
+            raise RuntimeError(
+                "CONFLUENCE_URL, CONFLUENCE_USERNAME and CONFLUENCE_TOKEN must be set"
+            )
+        if not self.url.endswith('/'):
+            self.url += '/'
+        self.session = requests.Session()
+        self.session.auth = (self.username, self.token)
+        self.session.headers.update({"Content-Type": "application/json"})
+
+    def _make_request(
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        method: str = "GET",
+        json: Any = None,
+    ) -> Dict[str, Any]:
+        url = endpoint if endpoint.startswith("http") else f"{self.url}{endpoint}"
+        response = self.session.request(method, url, params=params, json=json)
+        if not response.ok:
+            raise HTTPException(status_code=response.status_code, detail=response.text)
+        return response.json()
+
+    def _make_direct_request(self, url: str) -> Dict[str, Any]:
+        response = self.session.get(url)
+        if not response.ok:
+            raise HTTPException(status_code=response.status_code, detail=response.text)
+        return response.json()
+
+    def search(
+        self,
+        cql_query: str,
+        batch_size: int = 25,
+        limit: int = 100,
+        cursor: Optional[str] = None,
+        expand: Optional[List[str]] = None,
+        cql_context: Optional[str] = None,
+        excerpt: Optional[str] = None,
+        include_archived_spaces: bool = False,
+        exclude_current_spaces: bool = False,
+    ) -> Dict[str, Any]:
+        """Search Confluence using CQL with cursor-based pagination."""
+        endpoint = f"{self.url}rest/api/search"
+        params = {
+            "cql": cql_query,
+            "limit": min(batch_size, limit),
+        }
+        if cursor:
+            params["cursor"] = cursor
+        if cql_context:
+            params["cqlcontext"] = cql_context
+        if expand:
+            params["expand"] = ",".join(expand)
+        if excerpt:
+            params["excerpt"] = excerpt
+        if include_archived_spaces:
+            params["includeArchivedSpaces"] = "true"
+        if exclude_current_spaces:
+            params["excludeCurrentSpaces"] = "true"
+
+        response = self._make_request(endpoint, params)
+        result = response.copy()
+        all_results = response.get("results", [])
+        results_count = len(all_results)
+
+        while (
+            "_links" in response
+            and "next" in response["_links"]
+            and results_count < limit
+        ):
+            next_link = response["_links"]["next"]
+            if next_link.startswith("/"):
+                base_url = self.url.rstrip("/") if self.url else ""
+                next_url = f"{base_url}{next_link}"
+            else:
+                next_url = next_link
+            response = self._make_direct_request(next_url)
+            new_results = response.get("results", [])
+            all_results.extend(new_results)
+            results_count = len(all_results)
+
+        result["results"] = all_results[:limit]
+        result["size"] = len(result["results"])
+        return result
+
+    def get_page(self, page_id: str) -> Dict[str, Any]:
+        endpoint = f"rest/api/content/{page_id}"
+        return self._make_request(endpoint, params={"expand": "body.storage,version"})
+
+    def list_pages(self) -> List[Dict[str, Any]]:
+        cql = f"space={self.space_key} and type=page"
+        if self.parent_page:
+            cql += f" and ancestor={self.parent_page}"
+        data = self.search(cql, limit=1000)
+        return data.get("results", [])
+
+    def create_page(self, title: str, content: str) -> Dict[str, Any]:
+        if not self.space_key:
+            raise HTTPException(status_code=500, detail="CONFLUENCE_SPACE_KEY not set")
+        parent_id = self.parent_page
+        if parent_id:
+            cql = f"id={parent_id}"
+            self.search(cql, limit=1)
+        data = {
+            "type": "page",
+            "title": title,
+            "space": {"key": self.space_key},
+            "body": {"storage": {"value": content, "representation": "storage"}},
+        }
+        if parent_id:
+            data["ancestors"] = [{"id": parent_id}]
+        return self._make_request("rest/api/content", method="POST", json=data)
+
+    def update_page(self, page_id: str, title: Optional[str], content: Optional[str]) -> Dict[str, Any]:
+        page = self.get_page(page_id)
+        version = page.get("version", {}).get("number", 1)
+        new_version = version + 1
+        data = {
+            "id": page_id,
+            "type": "page",
+            "title": title or page["title"],
+            "version": {"number": new_version},
+            "body": {
+                "storage": {
+                    "value": content or page["body"]["storage"]["value"],
+                    "representation": "storage",
+                }
+            },
+        }
+        return self._make_request(f"rest/api/content/{page_id}", method="PUT", json=data)
+
+    def delete_page(self, page_id: str) -> None:
+        self._make_request(f"rest/api/content/{page_id}", method="DELETE")

--- a/servers/confluence_toolset_with_scope_restrictions/main.py
+++ b/servers/confluence_toolset_with_scope_restrictions/main.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+from .confluence_client import ConfluenceClient
+
+client = ConfluenceClient()
+app = FastAPI(title="Confluence API")
+
+
+class PageCreate(BaseModel):
+    title: str
+    content: str
+
+
+class PageUpdate(BaseModel):
+    title: Optional[str] = Field(None, description="New title")
+    content: Optional[str] = Field(None, description="New content in storage format")
+
+
+@app.get("/pages", summary="List pages")
+def list_pages():
+    return client.list_pages()
+
+
+@app.get("/pages/{page_id}", summary="Read page")
+def read_page(page_id: str):
+    return client.get_page(page_id)
+
+
+@app.post("/pages", summary="Create page")
+def create_page(data: PageCreate):
+    return client.create_page(data.title, data.content)
+
+
+@app.put("/pages/{page_id}", summary="Update page")
+def update_page(page_id: str, data: PageUpdate):
+    return client.update_page(page_id, data.title, data.content)
+
+
+@app.delete("/pages/{page_id}", summary="Delete page")
+def remove_page(page_id: str):
+    client.delete_page(page_id)
+    return {"status": "deleted"}
+
+
+@app.get("/search", summary="Search pages")
+def search(cql: str, limit: int = 100):
+    return client.search(cql_query=cql, limit=limit)

--- a/servers/confluence_toolset_with_scope_restrictions/requirements.txt
+++ b/servers/confluence_toolset_with_scope_restrictions/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+requests
+pydantic


### PR DESCRIPTION
## Summary
- add a new `confluence_toolset_with_scope_restrictions` server for Confluence Cloud
- document new server in root README
- modularize Confluence client into `confluence_client.py`

## Testing
- `python -m py_compile servers/confluence_toolset_with_scope_restrictions/main.py servers/confluence_toolset_with_scope_restrictions/confluence_client.py`
- `python -m pip install -r servers/confluence_toolset_with_scope_restrictions/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68470d062f54832ba4a3721e1dc8161f