### PR TITLE
Improve Confluence permissions and output

### DIFF
--- a/servers/confluence_toolset_with_scope_restrictions/README.md
+++ b/servers/confluence_toolset_with_scope_restrictions/README.md
@@ -8,6 +8,8 @@ A simple FastAPI server to interact with Confluence Cloud pages.
 - `CONFLUENCE_TOKEN` – API token for authentication
 - `CONFLUENCE_SPACE_KEY` – Space key where new pages are created
 - `CONFLUENCE_PARENT_PAGE` – *(optional)* Parent page ID limiting write operations
+  
+  When this variable is set, all write operations (create, update and delete) are allowed only on pages that are descendants of the configured parent page.
 
 ## Quickstart
 ```bash
@@ -16,3 +18,7 @@ pip install -r requirements.txt
 uvicorn main:app --reload
 ```
 Then visit [http://localhost:8000/docs](http://localhost:8000/docs).
+
+### Creating Pages
+
+The `/pages` endpoint accepts an optional `parent_id` field allowing you to specify under which Confluence page the new page should be created. When scope restrictions are enabled, the provided `parent_id` must be a descendant of `CONFLUENCE_PARENT_PAGE`.

--- a/servers/confluence_toolset_with_scope_restrictions/main.py
+++ b/servers/confluence_toolset_with_scope_restrictions/main.py
@@ -12,6 +12,7 @@ app = FastAPI(title="Confluence API")
 class PageCreate(BaseModel):
     title: str
     content: str
+    parent_id: Optional[str] = Field(None, description="Parent page ID")
 
 
 class PageUpdate(BaseModel):
@@ -31,7 +32,7 @@ def read_page(page_id: str):
 
 @app.post("/pages", summary="Create page")
 def create_page(data: PageCreate):
-    return client.create_page(data.title, data.content)
+    return client.create_page(data.title, data.content, data.parent_id)
 
 
 @app.put("/pages/{page_id}", summary="Update page")

--- a/servers/confluence_toolset_with_scope_restrictions/requirements.txt
+++ b/servers/confluence_toolset_with_scope_restrictions/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]
 requests
 pydantic
 python-dotenv
+html2text


### PR DESCRIPTION
## Summary
- restrict update and delete to pages under configured parent page
- allow specifying a `parent_id` when creating pages
- filter fields returned from `list_pages`
- convert HTML to Markdown using `html2text`
- document new behaviour and add `html2text` dependency

## Testing
- `python -m py_compile servers/confluence_toolset_with_scope_restrictions/*.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_684721d3e504832b9fa2c5e4fa1763c8