### PR TITLE
Replace assertion with RuntimeError for missing credentials in ConfluenceClient

### DIFF
--- a/servers/confluence_toolset_with_scope_restrictions/confluence_client.py
+++ b/servers/confluence_toolset_with_scope_restrictions/confluence_client.py
@@ -27,8 +27,9 @@ class ConfluenceClient:
         if self.url and not self.url.endswith('/'):
             self.url += '/'
         self.session = requests.Session()
-        # Ensure username and token are not None before setting auth
-        assert self.username is not None and self.token is not None, "Username and token must not be None"
+        if self.username is None or self.token is None:
+            raise RuntimeError("Username and token must not be None")
+        self.session.auth = (self.username, self.token)
         self.session.auth = (self.username, self.token)
         self.session.headers.update({"Content-Type": "application/json"})
 


### PR DESCRIPTION
Change the error handling in ConfluenceClient to raise a RuntimeError when the username or token is missing, improving clarity in error reporting.