### PR TITLE
Fix duplicate auth setup in Confluence client

### DIFF
--- a/servers/confluence_toolset_with_scope_restrictions/confluence_client.py
+++ b/servers/confluence_toolset_with_scope_restrictions/confluence_client.py
@@ -30,7 +30,6 @@ class ConfluenceClient:
         if self.username is None or self.token is None:
             raise RuntimeError("Username and token must not be None")
         self.session.auth = (self.username, self.token)
-        self.session.auth = (self.username, self.token)
         self.session.headers.update({"Content-Type": "application/json"})
 
     def _html_to_markdown(self, html: str) -> str:


### PR DESCRIPTION
## Summary
- remove duplicated `self.session.auth` line in `ConfluenceClient.__init__`

## Testing
- `python -m py_compile servers/confluence_toolset_with_scope_restrictions/confluence_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68480bd23fe8832bb57f7904f3d3b4ff