### PR TITLE
Implement Confluence page summary endpoint

### DIFF
--- a/servers/confluence_toolset_with_scope_restrictions/README.md
+++ b/servers/confluence_toolset_with_scope_restrictions/README.md
@@ -23,6 +23,23 @@ Then visit [http://localhost:8000/docs](http://localhost:8000/docs).
 
 The `/pages` endpoint accepts an optional `parent_id` field allowing you to specify under which Confluence page the new page should be created. When scope restrictions are enabled, the provided `parent_id` must be a descendant of `CONFLUENCE_PARENT_PAGE`.
 
+### Reading Pages
+
+`GET /pages/{page_id}` returns a page summary with Markdown content:
+
+```json
+{
+  "id": "12345",
+  "title": "Example Page",
+  "content": "# Heading\nBody...",
+  "url": "https://your-site.atlassian.net/wiki/....",
+  "last_modified": "Yesterday",
+  "parent_page_id": "67890",
+  "parent_page_title": "Parent",
+  "modifier": "Alice"
+}
+```
+
 ### Fetching Inline Comments
 
 Use `/pages/{page_id}/inline-comments` to list inline comments on a page. Include

--- a/servers/confluence_toolset_with_scope_restrictions/main.py
+++ b/servers/confluence_toolset_with_scope_restrictions/main.py
@@ -27,7 +27,7 @@ def list_pages():
 
 @app.get("/pages/{page_id}", summary="Read page")
 def read_page(page_id: str):
-    return client.get_page(page_id)
+    return client.get_page_summary(page_id)
 
 
 @app.post("/pages", summary="Create page")


### PR DESCRIPTION
## Summary
- expose `get_page_summary` in `ConfluenceClient`
- use the new method in `GET /pages/{page_id}`
- document the page summary response

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68480bcd2994832bb8af9d09e473f14b