### PR TITLE
Add optional children fetch for Confluence pages

### DIFF
--- a/servers/confluence_toolset_with_scope_restrictions/README.md
+++ b/servers/confluence_toolset_with_scope_restrictions/README.md
@@ -40,6 +40,8 @@ The `/pages` endpoint accepts an optional `parent_id` field allowing you to spec
 }
 ```
 
+Add the query parameter `include_children=true` to also return all descendant pages in a nested `children` field.
+
 ### Fetching Inline Comments
 
 Use `/pages/{page_id}/inline-comments` to list inline comments on a page. Include

--- a/servers/confluence_toolset_with_scope_restrictions/main.py
+++ b/servers/confluence_toolset_with_scope_restrictions/main.py
@@ -26,8 +26,8 @@ def list_pages():
 
 
 @app.get("/pages/{page_id}", summary="Read page")
-def read_page(page_id: str):
-    return client.get_page_summary(page_id)
+def read_page(page_id: str, include_children: bool = False):
+    return client.get_page_summary(page_id, include_children=include_children)
 
 
 @app.post("/pages", summary="Create page")


### PR DESCRIPTION
## Summary
- add recursive children fetch in `ConfluenceClient.get_page_summary`
- expose `include_children` query param on `GET /pages/{page_id}`
- document the new option in README

## Testing
- `python -m py_compile servers/confluence_toolset_with_scope_restrictions/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68482710269c832b9320d46e6613ac73